### PR TITLE
Default to light mode, fix stale Spotify now-playing on refresh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ const BackgroundPattern = () => (
 function App() {
   const [mode, setMode] = useState<"light" | "dark">(() => {
     const savedMode = localStorage.getItem("themeMode");
-    return savedMode === "light" || savedMode === "dark" ? savedMode : "dark";
+    return savedMode === "light" || savedMode === "dark" ? savedMode : "light";
   });
 
   const theme = useMemo(

--- a/src/components/SpotifyNowPlaying.tsx
+++ b/src/components/SpotifyNowPlaying.tsx
@@ -21,8 +21,9 @@ export default function SpotifyNowPlaying() {
   useEffect(() => {
     const fetchLastPlayed = async () => {
       try {
-        const response = await fetch(ENDPOINTS.LAST_PLAYED, {
+        const response = await fetch(`${ENDPOINTS.LAST_PLAYED}?t=${Date.now()}`, {
           method: "GET",
+          cache: "no-store",
           headers: {
             Accept: "application/json",
           },


### PR DESCRIPTION
## Summary
- Light mode is now the default for first-time visitors (previously dark)
- Fixed the "now playing" widget showing a stale track after a page refresh: the fetch had no cache directive, so the browser (or an intermediary CDN) could keep serving a cached response after the track changed on Spotify. Added a cache-busting timestamp param + `cache: "no-store"` so every load hits the backend fresh — this doesn't add any blocking delay, the widget still loads asynchronously with its existing skeleton state, so first paint isn't affected.

## Test plan
- [x] `npm run build` / `npm run lint` clean
- [x] Verified with cleared localStorage that a fresh visitor gets light mode
- [ ] Can't fully verify the Spotify fix locally — the backend is external (`VITE_BACKEND_URL`) and isn't configured in local dev, so please confirm on the live deploy that changing tracks + refreshing shows the update