### PR TITLE
Add portfolio observability: analytics dashboard, visit emails, chat logging

### DIFF
--- a/api/_lib/analyticsAuth.ts
+++ b/api/_lib/analyticsAuth.ts
@@ -1,0 +1,35 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const COOKIE_NAME = "analytics_session";
+const SESSION_TTL_SECONDS = 60 * 60 * 12; // 12 hours
+
+function sign(expiry: number): string {
+  const secret = process.env.ANALYTICS_PASSWORD ?? "";
+  return createHmac("sha256", secret).update(String(expiry)).digest("hex");
+}
+
+export function createSessionCookie(): string {
+  const expiry = Date.now() + SESSION_TTL_SECONDS * 1000;
+  const value = `${expiry}.${sign(expiry)}`;
+  return `${COOKIE_NAME}=${value}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=${SESSION_TTL_SECONDS}`;
+}
+
+export function isAuthenticated(cookieHeader: string | undefined): boolean {
+  if (!cookieHeader || !process.env.ANALYTICS_PASSWORD) return false;
+
+  const match = cookieHeader.match(new RegExp(`${COOKIE_NAME}=([^;]+)`));
+  if (!match) return false;
+
+  const [expiryStr, signature] = match[1].split(".");
+  const expiry = Number(expiryStr);
+  if (!expiry || Date.now() > expiry) return false;
+
+  const expected = sign(expiry);
+  const expectedBuf = Buffer.from(expected);
+  const actualBuf = Buffer.from(signature ?? "");
+  if (expectedBuf.length !== actualBuf.length) return false;
+
+  return timingSafeEqual(expectedBuf, actualBuf);
+}
+
+export { COOKIE_NAME };

--- a/api/_lib/ratelimit.ts
+++ b/api/_lib/ratelimit.ts
@@ -1,10 +1,5 @@
 import { Ratelimit } from "@upstash/ratelimit";
-import { Redis } from "@upstash/redis";
-
-const hasUpstash =
-  !!process.env.UPSTASH_REDIS_REST_URL && !!process.env.UPSTASH_REDIS_REST_TOKEN;
-
-const redis = hasUpstash ? Redis.fromEnv() : null;
+import { redis } from "./redis.js";
 
 // Per-IP sliding window - the main abuse guard.
 const perIpLimit = redis

--- a/api/_lib/redis.ts
+++ b/api/_lib/redis.ts
@@ -1,0 +1,7 @@
+import { Redis } from "@upstash/redis";
+
+const hasUpstash =
+  (!!process.env.UPSTASH_REDIS_REST_URL || !!process.env.KV_REST_API_URL) &&
+  (!!process.env.UPSTASH_REDIS_REST_TOKEN || !!process.env.KV_REST_API_TOKEN);
+
+export const redis = hasUpstash ? Redis.fromEnv() : null;

--- a/api/_lib/resend.ts
+++ b/api/_lib/resend.ts
@@ -1,0 +1,46 @@
+const NOTIFY_TO = "zekariassolomon1122@gmail.com";
+
+export async function sendVisitEmail(details: {
+  path: string;
+  country?: string;
+  city?: string;
+  referrer?: string;
+  userAgent?: string;
+}) {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return;
+
+  const from = process.env.RESEND_FROM ?? "Portfolio <onboarding@resend.dev>";
+  const location = [details.city, details.country].filter(Boolean).join(", ") || "unknown location";
+
+  await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from,
+      to: NOTIFY_TO,
+      subject: "Someone's on your portfolio",
+      html: `
+        <p>New visit on your portfolio.</p>
+        <ul>
+          <li><strong>Page:</strong> ${escapeHtml(details.path)}</li>
+          <li><strong>Location:</strong> ${escapeHtml(location)}</li>
+          <li><strong>Referrer:</strong> ${escapeHtml(details.referrer || "direct")}</li>
+          <li><strong>Device:</strong> ${escapeHtml(details.userAgent || "unknown")}</li>
+        </ul>
+      `,
+    }),
+  }).catch(() => {
+    // Best-effort notification - never let this break the visitor's request.
+  });
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/api/analytics/auth.ts
+++ b/api/analytics/auth.ts
@@ -1,0 +1,24 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createSessionCookie } from "../_lib/analyticsAuth.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "POST") {
+    res.status(405).end();
+    return;
+  }
+
+  const configuredPassword = process.env.ANALYTICS_PASSWORD;
+  if (!configuredPassword) {
+    res.status(503).json({ error: "not_configured" });
+    return;
+  }
+
+  const { password } = (req.body ?? {}) as { password?: string };
+  if (password !== configuredPassword) {
+    res.status(401).json({ error: "invalid_password" });
+    return;
+  }
+
+  res.setHeader("Set-Cookie", createSessionCookie());
+  res.status(200).json({ ok: true });
+}

--- a/api/analytics/data.ts
+++ b/api/analytics/data.ts
@@ -1,0 +1,104 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { isAuthenticated } from "../_lib/analyticsAuth.js";
+import { redis } from "../_lib/redis.js";
+
+const DAYS_OF_HISTORY = 30;
+const RECENT_LIMIT = 200;
+
+interface VisitEntry {
+  visitorId: string;
+  path: string;
+  country: string;
+  city: string;
+  referrer: string;
+  userAgent: string;
+  timestamp: number;
+}
+
+interface SessionEntry {
+  sessionId: string;
+  path: string;
+  duration: number;
+  timestamp: number;
+}
+
+interface ChatQuestionEntry {
+  question: string;
+  timestamp: number;
+}
+
+function lastNDays(n: number): string[] {
+  const days: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    days.push(d.toISOString().slice(0, 10));
+  }
+  return days;
+}
+
+function sumHashes(hashes: (Record<string, string> | null)[]): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const hash of hashes) {
+    if (!hash) continue;
+    for (const [key, value] of Object.entries(hash)) {
+      totals[key] = (totals[key] ?? 0) + Number(value);
+    }
+  }
+  return totals;
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (!isAuthenticated(req.headers.cookie)) {
+    res.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  if (!redis) {
+    res.status(200).json({
+      pageviews: {},
+      clicks: {},
+      sessions: [],
+      visits: [],
+      chatQuestions: [],
+    });
+    return;
+  }
+
+  const days = lastNDays(DAYS_OF_HISTORY);
+
+  const [pageviewHashes, clickHashes, rawSessions, rawVisits, rawQuestions] =
+    await Promise.all([
+      Promise.all(days.map((d) => redis!.hgetall<Record<string, string>>(`analytics:pageviews:${d}`))),
+      Promise.all(days.map((d) => redis!.hgetall<Record<string, string>>(`analytics:clicks:${d}`))),
+      redis.lrange("analytics:sessions", 0, RECENT_LIMIT - 1),
+      redis.lrange("analytics:visits", 0, RECENT_LIMIT - 1),
+      redis.lrange("analytics:chat_questions", 0, RECENT_LIMIT - 1),
+    ]);
+
+  const parseEntry = <T,>(raw: unknown): T | null => {
+    if (typeof raw !== "string") return raw as T;
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      return null;
+    }
+  };
+
+  const sessions = (rawSessions as unknown[])
+    .map((s) => parseEntry<SessionEntry>(s))
+    .filter((s): s is SessionEntry => s !== null);
+  const visits = (rawVisits as unknown[])
+    .map((v) => parseEntry<VisitEntry>(v))
+    .filter((v): v is VisitEntry => v !== null);
+  const chatQuestions = (rawQuestions as unknown[])
+    .map((q) => parseEntry<ChatQuestionEntry>(q))
+    .filter((q): q is ChatQuestionEntry => q !== null);
+
+  res.status(200).json({
+    pageviews: sumHashes(pageviewHashes),
+    clicks: sumHashes(clickHashes),
+    sessions,
+    visits,
+    chatQuestions,
+  });
+}

--- a/api/analytics/track.ts
+++ b/api/analytics/track.ts
@@ -1,0 +1,112 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { redis } from "../_lib/redis.js";
+import { sendVisitEmail } from "../_lib/resend.js";
+
+const MAX_LIST_LENGTH = 500;
+const MAX_STRING_LENGTH = 300;
+
+interface TrackBody {
+  type?: "pageview" | "click" | "session_end";
+  path?: string;
+  label?: string;
+  sessionId?: string;
+  visitorId?: string;
+  duration?: number;
+  referrer?: string;
+  isNewSession?: boolean;
+}
+
+function clip(value: unknown, max = MAX_STRING_LENGTH): string {
+  return typeof value === "string" ? value.slice(0, max) : "";
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== "POST") {
+    res.status(405).end();
+    return;
+  }
+  if (!redis) {
+    res.status(204).end();
+    return;
+  }
+
+  const body = req.body as TrackBody;
+  const path = clip(body.path, 200) || "/";
+  const sessionId = clip(body.sessionId, 100);
+  const visitorId = clip(body.visitorId, 100);
+  const country = clip(req.headers["x-vercel-ip-country"], 50) || "unknown";
+  const city = clip(req.headers["x-vercel-ip-city"], 100) || "unknown";
+  const userAgent = clip(req.headers["user-agent"], 200);
+  const timestamp = Date.now();
+
+  try {
+    switch (body.type) {
+      case "pageview": {
+        await redis.hincrby(`analytics:pageviews:${todayKey()}`, path, 1);
+
+        if (body.isNewSession && visitorId) {
+          await redis
+            .lpush(
+              "analytics:visits",
+              JSON.stringify({
+                visitorId,
+                path,
+                country,
+                city,
+                referrer: clip(body.referrer, 200) || "direct",
+                userAgent,
+                timestamp,
+              })
+            )
+            .then(() => redis!.ltrim("analytics:visits", 0, MAX_LIST_LENGTH - 1));
+
+          const notifyKey = `analytics:notified:${visitorId}:${todayKey()}`;
+          const alreadyNotified = await redis.get(notifyKey);
+          if (!alreadyNotified) {
+            await redis.set(notifyKey, "1", { ex: 60 * 60 * 24 });
+            await sendVisitEmail({
+              path,
+              country,
+              city,
+              referrer: clip(body.referrer, 200),
+              userAgent,
+            });
+          }
+        }
+        break;
+      }
+      case "click": {
+        const label = clip(body.label, 50) || "unknown";
+        await redis.hincrby(`analytics:clicks:${todayKey()}`, label, 1);
+        break;
+      }
+      case "session_end": {
+        if (sessionId) {
+          await redis
+            .lpush(
+              "analytics:sessions",
+              JSON.stringify({
+                sessionId,
+                path,
+                duration: typeof body.duration === "number" ? body.duration : 0,
+                timestamp,
+              })
+            )
+            .then(() => redis!.ltrim("analytics:sessions", 0, MAX_LIST_LENGTH - 1));
+        }
+        break;
+      }
+      default:
+        res.status(400).end();
+        return;
+    }
+  } catch {
+    // Analytics must never break the visitor's experience.
+  }
+
+  res.status(204).end();
+}

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1,6 +1,22 @@
 import { openai, EMBEDDING_MODEL, EMBEDDING_DIMENSIONS, CHAT_MODEL } from "./_lib/openai.js";
 import { retrieveContext } from "./_lib/kb.js";
 import { checkRateLimit } from "./_lib/ratelimit.js";
+import { redis } from "./_lib/redis.js";
+
+const MAX_CHAT_QUESTION_LOG = 500;
+
+async function logChatQuestion(question: string) {
+  if (!redis) return;
+  try {
+    await redis.lpush(
+      "analytics:chat_questions",
+      JSON.stringify({ question, timestamp: Date.now() })
+    );
+    await redis.ltrim("analytics:chat_questions", 0, MAX_CHAT_QUESTION_LOG - 1);
+  } catch {
+    // Logging must never break the chat response.
+  }
+}
 
 export const config = { runtime: "edge" };
 
@@ -47,6 +63,8 @@ export default async function handler(req: Request): Promise<Response> {
   if (!message || message.length === 0 || message.length > MAX_MESSAGE_LENGTH) {
     return new Response("Invalid message", { status: 400 });
   }
+
+  await logChatQuestion(message);
 
   const history = (body.history ?? []).slice(-16).map((m) => ({
     role: m.role === "user" ? ("user" as const) : ("assistant" as const),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { ThemeProvider, createTheme } from "@mui/material";
 import CssBaseline from "@mui/material/CssBaseline";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router-dom";
 import Home from "./pages/Home";
 import Experience from "./pages/Experience";
 import Notes from "./pages/Notes";
@@ -9,7 +9,32 @@ import NotesDetail from "./pages/NotesDetail";
 import About from "./pages/About";
 import Projects from "./pages/Projects";
 import Tools from "./pages/Tools";
+import AnalyticsPage from "./pages/Analytics";
 import { Analytics } from "@vercel/analytics/react";
+import { trackPageview, trackSessionEnd, markPageEntered } from "./lib/analytics";
+
+function usePageAnalytics() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.pathname.startsWith("/analytics")) return;
+
+    trackPageview(location.pathname);
+    markPageEntered();
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) trackSessionEnd(location.pathname);
+    };
+    const handleUnload = () => trackSessionEnd(location.pathname);
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("beforeunload", handleUnload);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("beforeunload", handleUnload);
+    };
+  }, [location.pathname]);
+}
 
 const BackgroundPattern = () => (
   <div
@@ -31,6 +56,8 @@ const BackgroundPattern = () => (
 );
 
 function App() {
+  usePageAnalytics();
+
   const [mode, setMode] = useState<"light" | "dark">(() => {
     const savedMode = localStorage.getItem("themeMode");
     return savedMode === "light" || savedMode === "dark" ? savedMode : "light";
@@ -117,6 +144,10 @@ function App() {
         <Route
           path="/tools"
           element={<Tools toggleColorMode={toggleColorMode} />}
+        />
+        <Route
+          path="/analytics"
+          element={<AnalyticsPage toggleColorMode={toggleColorMode} />}
         />
       </Routes>
     </ThemeProvider>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,70 @@
+const VISITOR_ID_KEY = "analytics_visitor_id";
+const SESSION_ID_KEY = "analytics_session_id";
+const SESSION_STARTED_KEY = "analytics_session_started";
+
+function getVisitorId(): string {
+  let id = localStorage.getItem(VISITOR_ID_KEY);
+  if (!id) {
+    id = crypto.randomUUID();
+    localStorage.setItem(VISITOR_ID_KEY, id);
+  }
+  return id;
+}
+
+function getSessionId(): string {
+  let id = sessionStorage.getItem(SESSION_ID_KEY);
+  if (!id) {
+    id = crypto.randomUUID();
+    sessionStorage.setItem(SESSION_ID_KEY, id);
+  }
+  return id;
+}
+
+function isNewSession(): boolean {
+  if (sessionStorage.getItem(SESSION_STARTED_KEY)) return false;
+  sessionStorage.setItem(SESSION_STARTED_KEY, "1");
+  return true;
+}
+
+function send(payload: Record<string, unknown>) {
+  try {
+    fetch("/api/analytics/track", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      keepalive: true,
+      body: JSON.stringify(payload),
+    }).catch(() => {});
+  } catch {
+    // Analytics must never break the visitor's experience.
+  }
+}
+
+export function trackPageview(path: string) {
+  send({
+    type: "pageview",
+    path,
+    sessionId: getSessionId(),
+    visitorId: getVisitorId(),
+    referrer: document.referrer,
+    isNewSession: isNewSession(),
+  });
+}
+
+export function trackClick(label: string) {
+  send({ type: "click", label });
+}
+
+let pageEnteredAt = Date.now();
+
+export function markPageEntered() {
+  pageEnteredAt = Date.now();
+}
+
+export function trackSessionEnd(path: string) {
+  send({
+    type: "session_end",
+    path,
+    sessionId: getSessionId(),
+    duration: Date.now() - pageEnteredAt,
+  });
+}

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Typography,
+  TextField,
+  Button,
+  useTheme,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from "@mui/material";
+import { alpha } from "@mui/material/styles";
+import { motion } from "framer-motion";
+import Navbar from "../components/Navbar";
+import type { AnalyticsData } from "../types/analytics";
+
+interface Props {
+  toggleColorMode: () => void;
+}
+
+const ACCENT = "#0a8f4f";
+const ACCENT_DARK = "#7fd8a6";
+
+function StatTile({ label, value }: { label: string; value: string | number }) {
+  const theme = useTheme();
+  return (
+    <Box
+      sx={{
+        flex: "1 1 160px",
+        p: 2,
+        border: `1px solid ${alpha(theme.palette.text.primary, 0.1)}`,
+        borderRadius: 1.5,
+      }}
+    >
+      <Typography variant="h5" sx={{ fontWeight: 700 }}>
+        {value}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+function BarList({
+  title,
+  data,
+}: {
+  title: string;
+  data: Record<string, number>;
+}) {
+  const theme = useTheme();
+  const entries = Object.entries(data).sort((a, b) => b[1] - a[1]).slice(0, 10);
+  const max = entries.length ? entries[0][1] : 1;
+  const accent = theme.palette.mode === "dark" ? ACCENT_DARK : ACCENT;
+
+  return (
+    <Box sx={{ mb: 5 }}>
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ mb: 2, textTransform: "uppercase", letterSpacing: "1px", fontSize: "0.7rem" }}
+      >
+        {title}
+      </Typography>
+      {entries.length === 0 ? (
+        <Typography variant="body2" color="text.secondary" sx={{ opacity: 0.6 }}>
+          No data yet
+        </Typography>
+      ) : (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          {entries.map(([key, count]) => (
+            <Box key={key} sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+              <Typography
+                variant="body2"
+                sx={{ width: 220, flexShrink: 0, fontFamily: "monospace", fontSize: "0.8rem" }}
+                noWrap
+                title={key}
+              >
+                {key}
+              </Typography>
+              <Box sx={{ flex: 1, bgcolor: alpha(theme.palette.text.primary, 0.06), borderRadius: 0.5 }}>
+                <Box
+                  sx={{
+                    width: `${(count / max) * 100}%`,
+                    minWidth: 4,
+                    height: 16,
+                    bgcolor: accent,
+                    borderRadius: 0.5,
+                  }}
+                />
+              </Box>
+              <Typography variant="body2" sx={{ width: 40, textAlign: "right", flexShrink: 0 }}>
+                {count}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function median(values: number[]): number {
+  if (!values.length) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+const Analytics = ({ toggleColorMode }: Props) => {
+  const theme = useTheme();
+  const [authenticated, setAuthenticated] = useState(false);
+  const [checkingSession, setCheckingSession] = useState(true);
+  const [password, setPassword] = useState("");
+  const [authError, setAuthError] = useState<string | null>(null);
+  const [data, setData] = useState<AnalyticsData | null>(null);
+
+  const fetchData = async () => {
+    try {
+      const res = await fetch("/api/analytics/data");
+      if (res.ok) {
+        setData((await res.json()) as AnalyticsData);
+        setAuthenticated(true);
+      }
+    } catch {
+      // Falls through to the password prompt below.
+    }
+    setCheckingSession(false);
+  };
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- initial session check on mount, the standard fetch-on-mount pattern
+    void fetchData();
+  }, []);
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setAuthError(null);
+    try {
+      const res = await fetch("/api/analytics/auth", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+      if (res.ok) {
+        await fetchData();
+        return;
+      }
+    } catch {
+      // Falls through to the error message below.
+    }
+    setAuthError("Wrong password");
+  };
+
+  if (checkingSession) {
+    return null;
+  }
+
+  if (!authenticated || !data) {
+    return (
+      <Box
+        sx={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Box
+          component="form"
+          onSubmit={handleLogin}
+          sx={{ display: "flex", flexDirection: "column", gap: 2, width: 280 }}
+        >
+          <TextField
+            type="password"
+            label="Password"
+            size="small"
+            autoFocus
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            error={!!authError}
+            helperText={authError ?? " "}
+          />
+          <Button type="submit" variant="outlined">
+            Enter
+          </Button>
+        </Box>
+      </Box>
+    );
+  }
+
+  const durations = data.sessions.map((s) => s.duration).filter((d) => d > 0);
+  const avgDurationSec = durations.length
+    ? Math.round(durations.reduce((a, b) => a + b, 0) / durations.length / 1000)
+    : 0;
+  const medianDurationSec = Math.round(median(durations) / 1000);
+  const totalPageviews = Object.values(data.pageviews).reduce((a, b) => a + b, 0);
+
+  const countryCounts: Record<string, number> = {};
+  for (const v of data.visits) {
+    countryCounts[v.country || "unknown"] = (countryCounts[v.country || "unknown"] ?? 0) + 1;
+  }
+  const referrerCounts: Record<string, number> = {};
+  for (const v of data.visits) {
+    const ref = v.referrer && v.referrer !== "" ? v.referrer : "direct";
+    referrerCounts[ref] = (referrerCounts[ref] ?? 0) + 1;
+  }
+
+  return (
+    <Box
+      component={motion.div}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.5 }}
+      sx={{
+        minHeight: "100vh",
+        maxWidth: "900px",
+        margin: "0 auto",
+        padding: { xs: "2rem", md: "4rem" },
+        color: theme.palette.text.primary,
+      }}
+    >
+      <Navbar toggleColorMode={toggleColorMode} />
+
+      <Typography variant="h6" sx={{ mb: 3, fontWeight: 500 }}>
+        analytics (last 30 days)
+      </Typography>
+
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2, mb: 5 }}>
+        <StatTile label="Pageviews" value={totalPageviews} />
+        <StatTile label="Unique visits logged" value={data.visits.length} />
+        <StatTile label="Avg time on page" value={`${avgDurationSec}s`} />
+        <StatTile label="Median time on page" value={`${medianDurationSec}s`} />
+        <StatTile label="Chatbot questions" value={data.chatQuestions.length} />
+      </Box>
+
+      <BarList title="Top pages" data={data.pageviews} />
+      <BarList title="Button clicks" data={data.clicks} />
+      <BarList title="Visitor countries" data={countryCounts} />
+      <BarList title="Referrers" data={referrerCounts} />
+
+      <Box sx={{ mb: 5 }}>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ mb: 2, textTransform: "uppercase", letterSpacing: "1px", fontSize: "0.7rem" }}
+        >
+          Recent chatbot questions
+        </Typography>
+        {data.chatQuestions.length === 0 ? (
+          <Typography variant="body2" color="text.secondary" sx={{ opacity: 0.6 }}>
+            No data yet
+          </Typography>
+        ) : (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+            {data.chatQuestions.slice(0, 50).map((q, i) => (
+              <Box
+                key={i}
+                sx={{
+                  p: 1.25,
+                  border: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
+                  borderRadius: 1,
+                }}
+              >
+                <Typography variant="body2">{q.question}</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {new Date(q.timestamp).toLocaleString()}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+        )}
+      </Box>
+
+      <Box sx={{ mb: 5 }}>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ mb: 2, textTransform: "uppercase", letterSpacing: "1px", fontSize: "0.7rem" }}
+        >
+          Recent visits
+        </Typography>
+        <Box sx={{ overflowX: "auto" }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Time</TableCell>
+                <TableCell>Page</TableCell>
+                <TableCell>Location</TableCell>
+                <TableCell>Referrer</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {data.visits.slice(0, 50).map((v, i) => (
+                <TableRow key={i}>
+                  <TableCell>{new Date(v.timestamp).toLocaleString()}</TableCell>
+                  <TableCell>{v.path}</TableCell>
+                  <TableCell>
+                    {[v.city, v.country].filter((s) => s && s !== "unknown").join(", ") || "unknown"}
+                  </TableCell>
+                  <TableCell>{v.referrer || "direct"}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default Analytics;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -18,6 +18,7 @@ import Navbar from "../components/Navbar";
 import ChatTerminal from "../components/ChatTerminal";
 import SpotifyNowPlaying from "../components/SpotifyNowPlaying";
 import { impactStats, contact, resumeFiles } from "../data/facts";
+import { trackClick } from "../lib/analytics";
 
 interface Props {
   toggleColorMode: () => void;
@@ -157,6 +158,7 @@ const Home = ({ toggleColorMode }: Props) => {
             href="https://github.com/zekariasasaminew"
             target="_blank"
             rel="noopener"
+            onClick={() => trackClick("github")}
             sx={{
               ...LinkStyle,
               display: "flex",
@@ -169,6 +171,7 @@ const Home = ({ toggleColorMode }: Props) => {
             href="https://linkedin.com/in/zekarias-asaminew"
             target="_blank"
             rel="noopener"
+            onClick={() => trackClick("linkedin")}
             sx={{
               ...LinkStyle,
               display: "flex",
@@ -208,7 +211,10 @@ const Home = ({ toggleColorMode }: Props) => {
               component="a"
               href={resumeFiles.ai.href}
               download
-              onClick={() => setResumeAnchor(null)}
+              onClick={() => {
+                trackClick("resume-ai");
+                setResumeAnchor(null);
+              }}
             >
               Resume ({resumeFiles.ai.label})
             </MenuItem>
@@ -216,7 +222,10 @@ const Home = ({ toggleColorMode }: Props) => {
               component="a"
               href={resumeFiles.coreSwe.href}
               download
-              onClick={() => setResumeAnchor(null)}
+              onClick={() => {
+                trackClick("resume-core-swe");
+                setResumeAnchor(null);
+              }}
             >
               Resume ({resumeFiles.coreSwe.label})
             </MenuItem>

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,0 +1,29 @@
+export interface VisitEntry {
+  visitorId: string;
+  path: string;
+  country: string;
+  city: string;
+  referrer: string;
+  userAgent: string;
+  timestamp: number;
+}
+
+export interface SessionEntry {
+  sessionId: string;
+  path: string;
+  duration: number;
+  timestamp: number;
+}
+
+export interface ChatQuestionEntry {
+  question: string;
+  timestamp: number;
+}
+
+export interface AnalyticsData {
+  pageviews: Record<string, number>;
+  clicks: Record<string, number>;
+  sessions: SessionEntry[];
+  visits: VisitEntry[];
+  chatQuestions: ChatQuestionEntry[];
+}


### PR DESCRIPTION
## Summary
- New password-gated `/analytics` dashboard (not linked in the navbar - type the URL manually) showing: pageviews, button clicks (resume/github/linkedin), session duration, visitor countries/referrers, and recent RAG chatbot questions
- Email notification to zekariassolomon1122@gmail.com on a visit, rate-limited to once per visitor per day (via Redis) so repeat browsing doesn't spam the inbox
- Chatbot questions now get logged (full text) to Redis for review
- Bug fix: the Upstash Redis client's env var check only looked for `UPSTASH_REDIS_REST_URL`/`TOKEN`, but this project's Vercel KV integration only sets `KV_REST_API_URL`/`TOKEN` - `Redis.fromEnv()` supports both as a fallback, but the gate that decided whether to construct the client at all did not, so **the chat rate limiter has been silently failing open in production**. Fixed in `api/_lib/redis.ts`, and `ratelimit.ts` now reuses the shared client instead of duplicating the check.

## Required setup before this does anything in production
Add these two environment variables in Vercel (Production + Preview):
- `ANALYTICS_PASSWORD` - the dashboard password (also used as the HMAC signing key for the session cookie, so keep it reasonably long/random)
- `RESEND_API_KEY` - from your Resend account, for the visit-notification email. Optionally `RESEND_FROM` (defaults to `Portfolio <onboarding@resend.dev>`, which can only deliver to your own Resend account email - fine for this use case, but if you've verified your own domain in Resend, set this to something like `notifications@yourdomain.com` instead)

The existing `KV_REST_API_URL`/`KV_REST_API_TOKEN` (already configured) cover Redis storage - no new Redis setup needed.

## Test plan
- [x] `npm run build` / `npm run lint` / typecheck (client + api) all clean
- [x] Verified the full auth flow against the real linked Vercel project via `vercel dev` + curl: wrong password rejected, correct password issues a signed httpOnly cookie, cookie correctly gates `/api/analytics/data`
- [x] Verified locally that Redis/KV env vars are Production+Preview scoped only (not Development), so none of this local testing touched real data
- [x] Fixed a bug where any fetch failure on `/analytics` (e.g. transient network error) left the page stuck blank instead of falling back to the password prompt
- [ ] Can't verify the actual email delivery or real Redis read/write cycle until `RESEND_API_KEY` and `ANALYTICS_PASSWORD` are set in Vercel - worth a manual check on the live deploy after merging