### PR TITLE
Rebalance John Deere emphasis, hide resume, clear EY bullets, add About nav link

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -59,6 +59,18 @@ const Navbar = ({ toggleColorMode }: NavbarProps) => {
         }}
       >
         <Link
+          href="/about"
+          sx={{
+            ...(location.pathname === "/about" && {
+              borderBottom: `2px solid ${theme.palette.text.primary}`,
+              paddingBottom: "2px",
+              opacity: "1 !important",
+            }),
+          }}
+        >
+          About
+        </Link>
+        <Link
           href="/projects"
           sx={{
             ...(location.pathname === "/projects" && {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,3 +3,7 @@ const API_BASE_URL = import.meta.env.VITE_BACKEND_URL;
 export const ENDPOINTS = {
   LAST_PLAYED: `${API_BASE_URL}/api/spotify/current-track`,
 } as const;
+
+export const FEATURE_FLAGS = {
+  showResume: false,
+} as const;

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -14,10 +14,7 @@ export const experiences: Experience[] = [
       dark: "#FFE600",
       light: "#9B7F00",
     },
-    points: [
-      "Automated a manual, ticket-driven Excel report by building an agent to validate, clean, and update records daily, cutting a **2+ hour task to under a minute**",
-      "Audited team workflows to surface repetitive manual work and prioritized automation opportunities",
-    ],
+    points: [],
   },
   {
     company: "John Deere",
@@ -34,9 +31,7 @@ export const experiences: Experience[] = [
     points: [
       "Delivered features across **4 enterprise** `React`/`Next.js` apps, contributing to **$3.7M+** in projected annual savings",
       "Built an agentic pipeline correlating `New Relic` alerts with git commits to auto-diagnose failures & open draft PR fixes",
-      "Automated review, testing, and merging of Dependabot/Mend PRs, auto-fixing failing tests",
       "Introduced `GitHub Copilot CLI`, automating **90%+** of documentation & reducing **API latency 40%** via `Redis`",
-      "Cut **deployment time 85%** via automated `Kubernetes` CI/CD",
     ],
   },
   {

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -31,7 +31,9 @@ export const experiences: Experience[] = [
     points: [
       "Delivered features across **4 enterprise** `React`/`Next.js` apps, contributing to **$3.7M+** in projected annual savings",
       "Built an agentic pipeline correlating `New Relic` alerts with git commits to auto-diagnose failures & open draft PR fixes",
+      "Automated review, testing, and merging of Dependabot/Mend PRs, auto-fixing failing tests",
       "Introduced `GitHub Copilot CLI`, automating **90%+** of documentation & reducing **API latency 40%** via `Redis`",
+      "Cut **deployment time 85%** via automated `Kubernetes` CI/CD",
     ],
   },
   {

--- a/src/data/facts.ts
+++ b/src/data/facts.ts
@@ -50,10 +50,10 @@ export const leadershipStats: LeadershipStat[] = [
 ];
 
 export const impactStats: string[] = [
-  "$3.7M+ saved · John Deere",
   "Top external contributor · GitHub Desktop v3.5.4",
   "720+ users · CampusEx",
   "130 members led · GDG",
+  "$3.7M+ saved · John Deere",
 ];
 
 export const contact = {

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -23,7 +23,7 @@ export const aboutSections: Record<string, Section> = {
     title: "Tech Journey",
     image: "/images/about/tech2.JPG",
     description:
-      "From writing his first line of code to shipping enterprise applications at John Deere that support thousands of employees across more than ten factories - the kind of work where a bug isn't an abstraction, it's someone on a factory floor waiting on a tool. He introduced GitHub Copilot CLI as his team's primary development platform and ran a workshop on it at Augustana's first-ever hackathon. Outside of work, he builds in the open: jetbrains-acp (an ACP client for JetBrains IDEs) and instruct-sync, on top of his GitHub Desktop and React contributions. CampusEx, his campus marketplace, started when he noticed students tossing out perfectly good furniture at move-out.",
+      "From writing his first line of code to building agents inside a Big Four tax practice at EY and shipping enterprise applications at John Deere that support thousands of employees across more than ten factories - the kind of work where a bug isn't an abstraction, it's someone on a factory floor waiting on a tool. He introduced GitHub Copilot CLI as his team's primary development platform and ran a workshop on it at Augustana's first-ever hackathon. Outside of work, he builds in the open: jetbrains-acp (an ACP client for JetBrains IDEs) and instruct-sync, on top of his GitHub Desktop and React contributions. CampusEx, his campus marketplace, started when he noticed students tossing out perfectly good furniture at move-out.",
   },
   leadership: {
     id: "leadership",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -19,6 +19,7 @@ import ChatTerminal from "../components/ChatTerminal";
 import SpotifyNowPlaying from "../components/SpotifyNowPlaying";
 import { impactStats, contact, resumeFiles } from "../data/facts";
 import { trackClick } from "../lib/analytics";
+import { FEATURE_FLAGS } from "../config";
 
 interface Props {
   toggleColorMode: () => void;
@@ -190,46 +191,50 @@ const Home = ({ toggleColorMode }: Props) => {
           >
             <EmailOutlinedIcon />
           </Link>
-          <IconButton
-            onClick={(e) => setResumeAnchor(e.currentTarget)}
-            aria-label="Download resume"
-            sx={{
-              p: 0,
-              color: "inherit",
-              opacity: 0.85,
-              "&:hover": { opacity: 1, backgroundColor: "transparent" },
-            }}
-          >
-            <DescriptionOutlinedIcon />
-          </IconButton>
-          <Menu
-            anchorEl={resumeAnchor}
-            open={Boolean(resumeAnchor)}
-            onClose={() => setResumeAnchor(null)}
-          >
-            <MenuItem
-              component="a"
-              href={resumeFiles.ai.href}
-              download
-              onClick={() => {
-                trackClick("resume-ai");
-                setResumeAnchor(null);
-              }}
-            >
-              Resume ({resumeFiles.ai.label})
-            </MenuItem>
-            <MenuItem
-              component="a"
-              href={resumeFiles.coreSwe.href}
-              download
-              onClick={() => {
-                trackClick("resume-core-swe");
-                setResumeAnchor(null);
-              }}
-            >
-              Resume ({resumeFiles.coreSwe.label})
-            </MenuItem>
-          </Menu>
+          {FEATURE_FLAGS.showResume && (
+            <>
+              <IconButton
+                onClick={(e) => setResumeAnchor(e.currentTarget)}
+                aria-label="Download resume"
+                sx={{
+                  p: 0,
+                  color: "inherit",
+                  opacity: 0.85,
+                  "&:hover": { opacity: 1, backgroundColor: "transparent" },
+                }}
+              >
+                <DescriptionOutlinedIcon />
+              </IconButton>
+              <Menu
+                anchorEl={resumeAnchor}
+                open={Boolean(resumeAnchor)}
+                onClose={() => setResumeAnchor(null)}
+              >
+                <MenuItem
+                  component="a"
+                  href={resumeFiles.ai.href}
+                  download
+                  onClick={() => {
+                    trackClick("resume-ai");
+                    setResumeAnchor(null);
+                  }}
+                >
+                  Resume ({resumeFiles.ai.label})
+                </MenuItem>
+                <MenuItem
+                  component="a"
+                  href={resumeFiles.coreSwe.href}
+                  download
+                  onClick={() => {
+                    trackClick("resume-core-swe");
+                    setResumeAnchor(null);
+                  }}
+                >
+                  Resume ({resumeFiles.coreSwe.label})
+                </MenuItem>
+              </Menu>
+            </>
+          )}
         </Box>
 
         {/* Spotify Now Playing */}


### PR DESCRIPTION
## Summary
- Add a `FEATURE_FLAGS.showResume` flag (`src/config.ts`, currently `false`) that hides the resume button on Home. Flip it back to `true` whenever it's ready — no other code changes needed.
- Clear EY's experience bullets (`points: []`) since a real write-up is coming after the internship wraps up. The card still shows title/dates/location and the "Read the full story →" link.
- Rebalance the John Deere-heavy portfolio framing: reorder the impact stats so John Deere's stat isn't leading, and rework the About page's "Tech Journey" copy to mention EY alongside John Deere instead of opening exclusively on John Deere. (John Deere's own experience bullets are untouched, per follow-up request — only EY's changed.)
- Add an "About" link to the Navbar — the `/about` route existed but had no way to reach it from navigation.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm run build` / `npm run preview` verified locally
- [x] Screenshot-checked Home (resume icon hidden), Experience (EY card with no bullets, John Deere bullets unchanged), About (EY + John Deere copy), and Navbar (About link routes to `/about`)
- [x] No new console errors on page load

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014D8NtVnyLM5HMpT9DmcUqF

---
_Generated by [Claude Code](https://claude.ai/code/session_014D8NtVnyLM5HMpT9DmcUqF)_