### PR TITLE
Left-align Spotify widget text

### DIFF
--- a/src/components/SpotifyNowPlaying.tsx
+++ b/src/components/SpotifyNowPlaying.tsx
@@ -92,6 +92,7 @@ export default function SpotifyNowPlaying() {
       direction={{ xs: "column", sm: "row" }}
       alignItems="flex-start"
       spacing={2}
+      sx={{ textAlign: "left" }}
     >
       <Box
         component={motion.div}


### PR DESCRIPTION
## Summary
- The hero section sets `text-align: center` on everything in it. The Spotify "now playing" widget inherited that, so the song name, artist, and timestamp were centering under each other instead of lining up left against the album art.
- Sets `text-align: left` explicitly on the widget's root so it's correct regardless of where it's rendered.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint .` clean
- [x] `npm run build` succeeds